### PR TITLE
Add nested containers and multi-item location scanning

### DIFF
--- a/templates/container_detail.html
+++ b/templates/container_detail.html
@@ -11,6 +11,8 @@
   <tr><th>Name</th><td>{{ container.name }}</td></tr>
   <tr><th>Size</th><td>{{ container.size }}</td></tr>
   <tr><th>Color</th><td>{{ container.color }}</td></tr>
+  <tr><th>Hierarchy</th><td>{{ container.full_path() }}</td></tr>
+  <tr><th>Parent Container</th><td>{% if container.parent %}<a href="/container/{{ container.parent.code }}">{{ container.parent.name or container.parent.code }}</a>{% endif %}</td></tr>
   <tr><th>Location</th><td>{{ container.location.full_path() if container.location else '' }}</td></tr>
   <tr><th>Created</th><td><span class="timestamp" data-ts="{{ container.created_at.isoformat() }}Z"></span> by {{ container.created_by.username if container.created_by else 'n/a' }}</td></tr>
   <tr><th>Updated</th><td><span class="timestamp" data-ts="{{ container.updated_at.isoformat() }}Z"></span> by {{ container.updated_by.username if container.updated_by else 'n/a' }}</td></tr>
@@ -57,8 +59,21 @@
       <div class="accordion-body p-0">
         <ul class="list-group list-group-flush">
         {% for item in container.items %}
-          {% set loc = item.location.full_path() if item.location else (container.location.full_path() if container.location else '') %}
-          <li class="list-group-item"><a href="/item/{{ item.code }}">{{ item.name }} ({{ item.quantity }}){% if loc %} / {{ loc }}{% endif %}</a></li>
+          <li class="list-group-item"><a href="/item/{{ item.code }}">{{ item.name }} ({{ item.quantity }}){% if item.hierarchy() %} / {{ item.hierarchy() }}{% endif %}</a></li>
+        {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div class="accordion-item">
+    <h2 class="accordion-header" id="headingContainers">
+      <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseContainers">Containers</button>
+    </h2>
+    <div id="collapseContainers" class="accordion-collapse collapse show">
+      <div class="accordion-body p-0">
+        <ul class="list-group list-group-flush">
+        {% for c in container.children %}
+          <li class="list-group-item"><a href="/container/{{ c.code }}">{{ c.full_path() }}</a></li>
         {% endfor %}
         </ul>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,7 @@
       <select class="form-select" name="container">
         <option value="">Container</option>
         {% for c in all_containers %}
-          <option value="{{ c.id }}" {% if request.args.get('container')==c.id|string %}selected{% endif %}>{{ c.name or c.code }}</option>
+          <option value="{{ c.id }}" {% if request.args.get('container')==c.id|string %}selected{% endif %}>{{ c.full_path() }}</option>
         {% endfor %}
       </select>
     </div>
@@ -52,7 +52,7 @@
         <ul class="list-group list-group-flush">
         {% for c in containers %}
           <li class="list-group-item">
-            <span title="container">📦</span> <a href="/container/{{ c.code }}">{{ c.name or c.code }}{% if c.location %} / {{ c.location.full_path() }}{% endif %}</a>
+            <span title="container">📦</span> <a href="/container/{{ c.code }}">{{ c.full_path() }}{% if c.location %} / {{ c.location.full_path() }}{% endif %}</a>
           </li>
         {% endfor %}
         </ul>

--- a/templates/item_detail.html
+++ b/templates/item_detail.html
@@ -11,7 +11,7 @@
   <tr><th>Type</th><td>{{ item.type }}</td></tr>
   <tr><th>Quantity</th><td>{{ item.quantity }}</td></tr>
   <tr><th>Location</th><td>{{ item.location.full_path() if item.location else '' }}</td></tr>
-  <tr><th>Container</th><td>{{ item.container.name if item.container else '' }}</td></tr>
+  <tr><th>Container</th><td>{% if item.container %}{{ item.container.full_path() }}{% endif %}</td></tr>
   <tr><th>Created</th><td><span class="timestamp" data-ts="{{ item.created_at.isoformat() }}Z"></span> by {{ item.created_by.username if item.created_by else 'n/a' }}</td></tr>
   <tr><th>Updated</th><td><span class="timestamp" data-ts="{{ item.updated_at.isoformat() }}Z"></span> by {{ item.updated_by.username if item.updated_by else 'n/a' }}</td></tr>
   <tr><th>Missing</th><td>{{ 'Yes' if item.missing else 'No' }}</td></tr>
@@ -61,7 +61,7 @@
       <div class="accordion-body p-0">
         <ul class="list-group list-group-flush">
           {% for h in item.histories|sort(attribute='timestamp', reverse=True) %}
-            <li class="list-group-item"><span class="timestamp" data-ts="{{ h.timestamp.isoformat() }}Z"></span> - {{ h.action }}{% if h.location %} {{ h.location.full_path() }}{% elif h.container %} {{ h.container.name or h.container.code }}{% endif %}{% if h.user %} by {{ h.user.username }}{% endif %}</li>
+            <li class="list-group-item"><span class="timestamp" data-ts="{{ h.timestamp.isoformat() }}Z"></span> - {{ h.action }}{% if h.location %} {{ h.location.full_path() }}{% elif h.container %} {{ h.container.full_path() }}{% endif %}{% if h.user %} by {{ h.user.username }}{% endif %}</li>
           {% endfor %}
         </ul>
       </div>

--- a/templates/location_detail.html
+++ b/templates/location_detail.html
@@ -53,7 +53,7 @@
         <ul class="list-group list-group-flush">
         {% for c in location.all_containers() %}
           {% set rel = c.path_from(location) %}
-          <li class="list-group-item"><a href="/container/{{ c.code }}">{{ c.name or c.code }}{% if rel %} / {{ rel }}{% endif %}</a></li>
+          <li class="list-group-item"><a href="/container/{{ c.code }}">{{ c.full_path() }}{% if rel %} / {{ rel }}{% endif %}</a></li>
         {% endfor %}
         </ul>
       </div>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -174,8 +174,7 @@ def test_location_unique_items():
         assert len(names) == 1
 
 
-def test_scan_container_in_container():
-    import time
+def test_scan_container_pair_timeout():
     client = app.test_client()
     login(client)
     with app.app_context():
@@ -183,19 +182,74 @@ def test_scan_container_in_container():
         loc = Location.query.filter_by(code='LC-testloc').first()
         c1 = Container(name='Inner', code='CT-inner', created_by=u, updated_by=u, location=loc)
         c2 = Container(name='Outer', code='CT-outer', created_by=u, updated_by=u, location=loc)
-        db.session.add_all([c1, c2])
+        dummy = Item(name='Temp', type='Tool', quantity=1, code='IT-temp', created_by=u, updated_by=u)
+        db.session.add_all([c1, c2, dummy])
         db.session.commit()
-        for code in (c1.code, c2.code):
+        for code in (c1.code, c2.code, dummy.code):
             if not Path(qr_path(code)).exists():
                 generate_qr(code)
     client.get(f'/scan/{c1.code}')
-    time.sleep(1)
-    client.get(f'/scan/{c2.code}')
+    client.get(f'/scan/{c2.code}?window=0')
+    client.get(f'/scan/{dummy.code}')
     with app.app_context():
         inner = Container.query.filter_by(code='CT-inner').first()
         outer = Container.query.filter_by(code='CT-outer').first()
         assert inner.parent_id == outer.id
         assert inner.location_id == outer.location_id
+
+
+def test_scan_multiple_items_to_container():
+    client = app.test_client()
+    login(client)
+    with app.app_context():
+        u = User.query.first()
+        loc = Location.query.filter_by(code='LC-testloc').first()
+        cont = Container(name='Box3', code='CT-box3', created_by=u, updated_by=u, location=loc)
+        i1 = Item(name='Screwdriver', type='Tool', quantity=1, code='IT-screw2', created_by=u, updated_by=u)
+        i2 = Item(name='Wrench', type='Tool', quantity=1, code='IT-wrench2', created_by=u, updated_by=u)
+        db.session.add_all([cont, i1, i2])
+        db.session.commit()
+        for code in (cont.code, i1.code, i2.code):
+            if not Path(qr_path(code)).exists():
+                generate_qr(code)
+    client.get(f'/scan/{cont.code}')
+    client.get(f'/scan/{i1.code}')
+    client.get(f'/scan/{i2.code}')
+    with app.app_context():
+        cont = Container.query.filter_by(code='CT-box3').first()
+        i1 = Item.query.filter_by(code='IT-screw2').first()
+        i2 = Item.query.filter_by(code='IT-wrench2').first()
+        assert i1.container_id == cont.id
+        assert i2.container_id == cont.id
+
+
+def test_scan_container_container_with_followups():
+    client = app.test_client()
+    login(client)
+    with app.app_context():
+        u = User.query.first()
+        loc = Location.query.filter_by(code='LC-testloc').first()
+        c1 = Container(name='Parent', code='CT-parent', created_by=u, updated_by=u, location=loc)
+        c2 = Container(name='Child', code='CT-child', created_by=u, updated_by=u, location=loc)
+        i1 = Item(name='Pliers', type='Tool', quantity=1, code='IT-pliers2', created_by=u, updated_by=u)
+        i2 = Item(name='Tape', type='Tool', quantity=1, code='IT-tape2', created_by=u, updated_by=u)
+        db.session.add_all([c1, c2, i1, i2])
+        db.session.commit()
+        for code in (c1.code, c2.code, i1.code, i2.code):
+            if not Path(qr_path(code)).exists():
+                generate_qr(code)
+    client.get(f'/scan/{c1.code}')
+    client.get(f'/scan/{c2.code}')
+    client.get(f'/scan/{i1.code}')
+    client.get(f'/scan/{i2.code}')
+    with app.app_context():
+        c1 = Container.query.filter_by(code='CT-parent').first()
+        c2 = Container.query.filter_by(code='CT-child').first()
+        i1 = Item.query.filter_by(code='IT-pliers2').first()
+        i2 = Item.query.filter_by(code='IT-tape2').first()
+        assert c2.parent_id == c1.id
+        assert i1.container_id == c1.id
+        assert i2.container_id == c1.id
 
 
 def test_scan_location_in_location():


### PR DESCRIPTION
## Summary
- allow containers to be nested within other containers and locations to track nested contents
- support pairing of locations and containers via scan API, including multi-item scanning to a single location
- add tests for container-container, location-location, and batch item registration flows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cbecbd7cc8324b995ca56c0010267