### PR TITLE
Fix container scan orientation and improve scan logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -1540,16 +1540,18 @@ def scan(code):
             process_pair(pending['first'], pending['second'])
             session.pop('pending_containers')
         else:
-            process_pair(pending['second'], pending['first'])
-            session['batch_container'] = {'code': pending['first'], 'time': now.isoformat(), 'window': window}
+            # Always treat the first scanned container as the child of the second
+            process_pair(pending['first'], pending['second'])
+            # Items scanned after a container-container pair should go into the second (parent) container
+            session['batch_container'] = {'code': pending['second'], 'time': now.isoformat(), 'window': window}
             session.pop('pending_containers')
             if isinstance(obj, (Item, Container)):
-                message = process_pair(code, pending['first'])
-                session['batch_container'] = {'code': pending['first'], 'time': now.isoformat(), 'window': window}
+                message = process_pair(code, pending['second'])
+                session['batch_container'] = {'code': pending['second'], 'time': now.isoformat(), 'window': window}
                 session.pop('last_scan', None)
                 handled = True
             elif isinstance(obj, Location):
-                message = process_pair(pending['first'], code)
+                message = process_pair(pending['second'], code)
                 session.pop('batch_container', None)
                 session['batch_location'] = {'code': code, 'time': now.isoformat(), 'window': window}
                 session.pop('last_scan', None)

--- a/templates/scanner.html
+++ b/templates/scanner.html
@@ -31,8 +31,12 @@ const scanLog = [];
 
 function addLog(text) {
   const time = new Date().toLocaleTimeString();
+  const li = document.createElement('li');
+  li.className = 'list-group-item';
+  li.innerHTML = `${time} - ${text}`;
+  logList.insertAdjacentElement('afterbegin', li);
   scanLog.push({ time, text });
-  logList.insertAdjacentHTML('afterbegin', `<li class="list-group-item">${time} - ${text}</li>`);
+  return li;
 }
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -115,17 +119,20 @@ function processNext(){
     return;
   }
   const decodedText = queue.shift();
+  const entry = addLog(`Scanned ${decodedText}`);
   beep();
   fetch(`/scan/${decodedText}?ajax=1&window=${windowSlider.value}`)
     .then(r=>r.json())
     .then(data=>{
       const msg = document.getElementById('scan-message');
-      const nameHtml = data.name ? ` - <b>${data.name}</b>` : '';
-      addLog(`Scanned ${decodedText}${nameHtml}`);
+      if(data.name){
+        entry.innerHTML += ` - <b>${data.name}</b>`;
+      }
       if(data.message){
         msg.innerHTML = data.message;
-        msg.classList.add('text-danger');
-        beep(880);
+        msg.classList.remove('text-danger');
+        // registration tone
+        beep(660);
         addLog(data.message);
         last = null;
         if(pendingTimeout){

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -78,6 +78,135 @@ def test_scan_pair_item_location():
         assert item.location_id == loc.id
 
 
+def test_scan_pair_item_container():
+    client = app.test_client()
+    login(client)
+    with app.app_context():
+        u = User.query.first()
+        loc = Location.query.filter_by(code='LC-testloc').first()
+        cont = Container(name='PairCont', code='CT-pairc', created_by=u, updated_by=u, location=loc)
+        item = Item(name='PairItem', type='Tool', quantity=1, code='IT-pairi', created_by=u, updated_by=u)
+        db.session.add_all([cont, item])
+        db.session.commit()
+        for code in (cont.code, item.code):
+            if not Path(qr_path(code)).exists():
+                generate_qr(code)
+        cont_code, item_code = cont.code, item.code
+    client.get(f'/scan/{item_code}')
+    client.get(f'/scan/{cont_code}')
+    with app.app_context():
+        cont = Container.query.filter_by(code=cont_code).first()
+        item = Item.query.filter_by(code=item_code).first()
+        assert item.container_id == cont.id
+
+
+def test_scan_pair_container_location():
+    client = app.test_client()
+    login(client)
+    with app.app_context():
+        u = User.query.first()
+        loc = Location(name='ScanRoom', code='LC-scanroom')
+        cont = Container(name='ScanBox', code='CT-scanbox', created_by=u, updated_by=u)
+        db.session.add_all([loc, cont])
+        db.session.commit()
+        for code in (loc.code, cont.code):
+            if not Path(qr_path(code)).exists():
+                generate_qr(code)
+        loc_code, cont_code = loc.code, cont.code
+    client.get(f'/scan/{cont_code}')
+    client.get(f'/scan/{loc_code}')
+    with app.app_context():
+        loc = Location.query.filter_by(code=loc_code).first()
+        cont = Container.query.filter_by(code=cont_code).first()
+        assert cont.location_id == loc.id
+
+
+def test_scan_pair_location_container():
+    client = app.test_client()
+    login(client)
+    with app.app_context():
+        u = User.query.first()
+        loc = Location(name='ScanRoom2', code='LC-scanroom2')
+        cont = Container(name='ScanBox2', code='CT-scanbox2', created_by=u, updated_by=u)
+        db.session.add_all([loc, cont])
+        db.session.commit()
+        for code in (loc.code, cont.code):
+            if not Path(qr_path(code)).exists():
+                generate_qr(code)
+        loc_code, cont_code = loc.code, cont.code
+    client.get(f'/scan/{loc_code}')
+    client.get(f'/scan/{cont_code}')
+    with app.app_context():
+        loc = Location.query.filter_by(code=loc_code).first()
+        cont = Container.query.filter_by(code=cont_code).first()
+        assert cont.location_id == loc.id
+
+
+def test_scan_item_item_noop():
+    client = app.test_client()
+    login(client)
+    with app.app_context():
+        u = User.query.first()
+        i1 = Item(name='Thing1', type='Tool', quantity=1, code='IT-thing1', created_by=u, updated_by=u)
+        i2 = Item(name='Thing2', type='Tool', quantity=1, code='IT-thing2', created_by=u, updated_by=u)
+        db.session.add_all([i1, i2])
+        db.session.commit()
+        for code in (i1.code, i2.code):
+            if not Path(qr_path(code)).exists():
+                generate_qr(code)
+        c1, c2 = i1.code, i2.code
+    client.get(f'/scan/{c1}')
+    client.get(f'/scan/{c2}')
+    with app.app_context():
+        i1 = Item.query.filter_by(code=c1).first()
+        i2 = Item.query.filter_by(code=c2).first()
+        assert i1.container_id is None and i1.location_id is None
+        assert i2.container_id is None and i2.location_id is None
+
+
+def test_scan_pair_location_item():
+    client = app.test_client()
+    login(client)
+    with app.app_context():
+        u = User.query.first()
+        loc = Location(name='LIroom', code='LC-liroom')
+        item = Item(name='LIitem', type='Tool', quantity=1, code='IT-liitem', created_by=u, updated_by=u)
+        db.session.add_all([loc, item])
+        db.session.commit()
+        for code in (loc.code, item.code):
+            if not Path(qr_path(code)).exists():
+                generate_qr(code)
+        loc_code, item_code = loc.code, item.code
+    client.get(f'/scan/{loc_code}')
+    client.get(f'/scan/{item_code}')
+    with app.app_context():
+        loc = Location.query.filter_by(code=loc_code).first()
+        item = Item.query.filter_by(code=item_code).first()
+        assert item.location_id == loc.id
+
+
+def test_scan_pair_container_item():
+    client = app.test_client()
+    login(client)
+    with app.app_context():
+        u = User.query.first()
+        loc = Location.query.filter_by(code='LC-testloc').first()
+        cont = Container(name='PairCont2', code='CT-pairc2', created_by=u, updated_by=u, location=loc)
+        item = Item(name='PairItem2', type='Tool', quantity=1, code='IT-pairi2', created_by=u, updated_by=u)
+        db.session.add_all([cont, item])
+        db.session.commit()
+        for code in (cont.code, item.code):
+            if not Path(qr_path(code)).exists():
+                generate_qr(code)
+        cont_code, item_code = cont.code, item.code
+    client.get(f'/scan/{cont_code}')
+    client.get(f'/scan/{item_code}')
+    with app.app_context():
+        cont = Container.query.filter_by(code=cont_code).first()
+        item = Item.query.filter_by(code=item_code).first()
+        assert item.container_id == cont.id
+
+
 def test_report_missing():
     client = app.test_client()
     login(client)
@@ -289,27 +418,28 @@ def test_scan_container_container_with_followups():
     with app.app_context():
         u = User.query.first()
         loc = Location.query.filter_by(code='LC-testloc').first()
-        c1 = Container(name='Parent', code='CT-parent', created_by=u, updated_by=u, location=loc)
-        c2 = Container(name='Child', code='CT-child', created_by=u, updated_by=u, location=loc)
+        child = Container(name='Child', code='CT-child', created_by=u, updated_by=u, location=loc)
+        parent = Container(name='Parent', code='CT-parent', created_by=u, updated_by=u, location=loc)
         i1 = Item(name='Pliers', type='Tool', quantity=1, code='IT-pliers2', created_by=u, updated_by=u)
         i2 = Item(name='Tape', type='Tool', quantity=1, code='IT-tape2', created_by=u, updated_by=u)
-        db.session.add_all([c1, c2, i1, i2])
+        db.session.add_all([child, parent, i1, i2])
         db.session.commit()
-        for code in (c1.code, c2.code, i1.code, i2.code):
+        for code in (child.code, parent.code, i1.code, i2.code):
             if not Path(qr_path(code)).exists():
                 generate_qr(code)
-    client.get(f'/scan/{c1.code}')
-    client.get(f'/scan/{c2.code}')
+    # Scan child first then parent; subsequent items should go into the parent
+    client.get(f'/scan/{child.code}')
+    client.get(f'/scan/{parent.code}')
     client.get(f'/scan/{i1.code}')
     client.get(f'/scan/{i2.code}')
     with app.app_context():
-        c1 = Container.query.filter_by(code='CT-parent').first()
-        c2 = Container.query.filter_by(code='CT-child').first()
+        child = Container.query.filter_by(code='CT-child').first()
+        parent = Container.query.filter_by(code='CT-parent').first()
         i1 = Item.query.filter_by(code='IT-pliers2').first()
         i2 = Item.query.filter_by(code='IT-tape2').first()
-        assert c2.parent_id == c1.id
-        assert i1.container_id == c1.id
-        assert i2.container_id == c1.id
+        assert child.parent_id == parent.id
+        assert i1.container_id == parent.id
+        assert i2.container_id == parent.id
 
 
 def test_location_path_order_and_title_case_numbers():


### PR DESCRIPTION
## Summary
- Ensure container-to-container scans treat the first container as a child of the second and direct subsequent items to the parent
- Play a distinct tone on successful registrations and avoid marking success messages as errors
- Log each scanned code immediately on the scanner page and update entries with resolved names
- Expand tests to cover all item, container and location scan permutations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ea6ab90a88324a594f4e06a512320