### PR TITLE
Ensure paired scans don't redirect to last object

### DIFF
--- a/app.py
+++ b/app.py
@@ -1613,6 +1613,7 @@ def scan(code):
                 else:
                     message = process_pair(last['code'], code)
                     session.pop('last_scan')
+                    handled = True
                     if isinstance(obj, Container) and isinstance(first_obj, Item):
                         session['batch_container'] = {'code': obj.code, 'time': now.isoformat(), 'window': window}
                     elif isinstance(obj, Location) and isinstance(first_obj, (Item, Container)):


### PR DESCRIPTION
## Summary
- Mark location/container pairing via last scan as handled to avoid stray redirects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ebcb7c11883249c60a9245f14a834